### PR TITLE
Changes to support parsing and exposing ICS data

### DIFF
--- a/CalendarKit-Swift/SwiftCal/CalendarEvent.swift
+++ b/CalendarKit-Swift/SwiftCal/CalendarEvent.swift
@@ -15,18 +15,23 @@ public enum EventStatus {
 }
 
 public struct EventAttendee {
-    
-    enum AttendeeRole {
+
+    public enum AttendeeRole {
         case chair
         case required
         case optional
         case non
     }
-    
+
     var url: String?
-    var name: String?
-    
-    var role: AttendeeRole?
+
+    public var name: String?
+
+    public var email: String?
+
+    public var status: String?
+
+    public var role: AttendeeRole?
 }
 
 public class EventRule: NSObject {
@@ -86,7 +91,9 @@ public class CalendarEvent: NSObject {
             return !attendees.isEmpty
         }
     }
-    
+
+    public var organizerEmail: String?
+
     var exceptionDates: [Date]?
     var hasExceptionDates: Bool {
         get {
@@ -102,6 +109,7 @@ public class CalendarEvent: NSObject {
     }
 
     var recurrenceRule: EventRule?
+    public var recurrenceRuleString: String?
     var hasRecurrenceRule: Bool {
         get {
             return (recurrenceRule != nil)
@@ -370,3 +378,4 @@ public class CalendarEvent: NSObject {
     }
     
 }
+

--- a/CalendarKit-Swift/SwiftCal/CalendarEvent.swift
+++ b/CalendarKit-Swift/SwiftCal/CalendarEvent.swift
@@ -24,13 +24,9 @@ public struct EventAttendee {
     }
 
     var url: String?
-
     public var name: String?
-
     public var email: String?
-
     public var status: String?
-
     public var role: AttendeeRole?
 }
 

--- a/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
+++ b/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
@@ -228,7 +228,7 @@ class ICSEventParser: NSObject {
         var locationString: NSString?
         
         let eventScanner = Scanner(string: icsString)
-        eventScanner.charactersToBeSkipped = characterSetWithNewLineSkip()
+        eventScanner.charactersToBeSkipped = newlineCharacterSet()
         eventScanner.scanUpTo(ICS.location, into: nil)
         eventScanner.scanUpTo("\n", into: &locationString)
 
@@ -266,8 +266,12 @@ class ICSEventParser: NSObject {
         eventScanner.scanUpTo(ICS.description, into: nil)
         eventScanner.scanUpTo("\n", into: &descriptionString)
 
-        // description could have newline characters in them (ideally newlines within the description should be represented by \\n as per ICS protocol)
-        // we know these newlines are characters within the description and not delimiters, since they start with a space or tab
+        // a multi-line description can have newline characters
+        // as per ICS protocol, the newline characters within a field should be represented by \\n
+        // however, some ICS files don't follow this rule and use the actual newline character (\n) instead
+        // the way to differentiate between this \n and the \n that acts as a delimiter between different fields in the ICS file is that
+        // the newline that starts after this \n has an empty string prefix
+        // are characters within the description and not delimiters, since they start with a space or tab
         var isMultiLineDescription = true;
 
         while isMultiLineDescription {
@@ -283,7 +287,7 @@ class ICSEventParser: NSObject {
         return descriptionString?.replacingOccurrences(of: ICS.description, with: "").replacingOccurrences(of: "\\n", with: "\n").replacingOccurrences(of: "\\", with: "").trimmingCharacters(in: CharacterSet.newlines)
     }
 
-    private static func characterSetWithNewLineSkip() -> CharacterSet {
+    private static func newlineCharacterSet() -> CharacterSet {
         var skipCharacterSet = CharacterSet()
         skipCharacterSet.insert(charactersIn: "\n")
         skipCharacterSet.insert(charactersIn: "\r\n")
@@ -319,7 +323,7 @@ class ICSEventParser: NSObject {
         var attendees = [EventAttendee]()
         
         let eventScanner = Scanner(string: icsString)
-        eventScanner.charactersToBeSkipped = characterSetWithNewLineSkip()
+        eventScanner.charactersToBeSkipped = newlineCharacterSet()
         
         var scanStatus = false;
         

--- a/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
+++ b/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
@@ -263,6 +263,7 @@ class ICSEventParser: NSObject {
         var descriptionString: NSString?
         
         let eventScanner = Scanner(string: icsString)
+        eventScanner.charactersToBeSkipped = newlineCharacterSet()
         eventScanner.scanUpTo(ICS.description, into: nil)
         eventScanner.scanUpTo("\n", into: &descriptionString)
 

--- a/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
+++ b/CalendarKit-Swift/SwiftCal/ICSEventParser.swift
@@ -228,8 +228,21 @@ class ICSEventParser: NSObject {
         var locationString: NSString?
         
         let eventScanner = Scanner(string: icsString)
+        eventScanner.charactersToBeSkipped = characterSetWithNewLineSkip()
         eventScanner.scanUpTo(ICS.location, into: nil)
         eventScanner.scanUpTo("\n", into: &locationString)
+
+        var isMultiLineDescription = true;
+
+        while isMultiLineDescription {
+            var nextLine: NSString?
+            eventScanner.scanUpTo("\n", into: &nextLine)
+            if let nextLine = nextLine, nextLine.hasPrefix(" ") {
+                locationString = locationString?.appending(nextLine.trimmingCharacters(in: .whitespacesAndNewlines)) as NSString?
+            } else {
+                isMultiLineDescription = false;
+            }
+        }
 
         return locationString?.replacingOccurrences(of: ICS.location, with: "").replacingOccurrences(of: "\\n", with: "\n").replacingOccurrences(of: "\\", with: "").trimmingCharacters(in: CharacterSet.newlines).fixIllegalICS()
     }
@@ -261,7 +274,7 @@ class ICSEventParser: NSObject {
             var nextLine: NSString?
             eventScanner.scanUpTo("\n", into: &nextLine)
             if let nextLine = nextLine, nextLine.hasPrefix(" ") {
-                descriptionString = descriptionString?.appending(nextLine.trimmingCharacters(in: .whitespacesAndNewlines)) as! NSString
+                descriptionString = descriptionString?.appending(nextLine.trimmingCharacters(in: .whitespacesAndNewlines)) as NSString?
             } else {
                 isMultiLineDescription = false;
             }

--- a/CalendarKit-Swift/SwiftCal/SwiftCal.swift
+++ b/CalendarKit-Swift/SwiftCal/SwiftCal.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class SwiftCal: NSObject {
 
-    var events = [CalendarEvent]()
+    public var events = [CalendarEvent]()
     public var timezone: NSTimeZone?
     
     @discardableResult public func addEvent(_ event: CalendarEvent) -> Int {
@@ -81,3 +81,4 @@ public class Read {
         return calendar
     }
 }
+

--- a/SwiftCal.podspec
+++ b/SwiftCal.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |spec|
+  spec.platform = :ios
+  spec.name         = 'SwiftCal'
+  spec.version      = '1.0.0'
+  spec.license      = { :type => 'MIT' }
+  spec.homepage     = 'https://github.com/superhuman/SwiftCal'
+  spec.authors      = { 'Sanket Firodiya' => 'sanket@superhuman.com' }
+  spec.summary      = 'A set of classes used to parse and handle iCalendar (.ICS) files'
+  spec.source       = { :git => 'https://github.com/superhuman/SwiftCal.git', :tag => '1.0.0' }
+  spec.source_files = 'SwiftCal/*.{swift}'
+  spec.frameworks = 'UIKit', 'Foundation'
+  spec.requires_arc = true
+end

--- a/SwiftCal.podspec
+++ b/SwiftCal.podspec
@@ -4,10 +4,10 @@ Pod::Spec.new do |spec|
   spec.version      = '1.0.0'
   spec.license      = { :type => 'MIT' }
   spec.homepage     = 'https://github.com/superhuman/SwiftCal'
-  spec.authors      = { 'Sanket Firodiya' => 'sanket@superhuman.com' }
+  spec.authors      = 'Sanket Firodiya'
   spec.summary      = 'A set of classes used to parse and handle iCalendar (.ICS) files'
   spec.source       = { :git => 'https://github.com/superhuman/SwiftCal.git', :tag => '1.0.0' }
-  spec.source_files = 'SwiftCal/*.{swift}'
+  spec.source_files = 'CalendarKit-Swift/SwiftCal/*.swift'
   spec.frameworks = 'UIKit', 'Foundation'
   spec.requires_arc = true
 end


### PR DESCRIPTION
- Parse name, email, status and role for attendee
- Make `AttendeeRole` public
- Parse variation of organizer `ORGANIZER:`
- Make `timeZone` optional since its not always present in ICS files
- Expose `organizerEmail`
- Parse location, attendees and description with newline characters in it
- Add podspec 